### PR TITLE
require parse-raw-data.js from local folder

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var whois = require('node-whois'),
 	log = console.log.bind(console),
-	parseRawData = require('parse-raw-data.js')
+	parseRawData = require('./parse-raw-data.js')
 
 module.exports = function(domain, options, cb){
 


### PR DESCRIPTION
If you try it on npm.com in your browser (button to the right) it won't find parse-raw-data.js. This will fix it by using './'.