### PR TITLE
Fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var whois = require('node-whois'),
+var whois = require('whois'),
 	log = console.log.bind(console),
 	parseRawData = require('./parse-raw-data.js')
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,122 +1,491 @@
 {
   "name": "whois-json",
-  "version": "2.0.0",
+  "version": "1.2.3",
+  "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
     "change-case": {
-      "version": "2.3.0",
-      "from": "https://registry.npmjs.org/change-case/-/change-case-2.3.0.tgz",
-      "resolved": "https://registry.npmjs.org/change-case/-/change-case-2.3.0.tgz",
+      "version": "https://registry.npmjs.org/change-case/-/change-case-2.3.0.tgz",
+      "integrity": "sha1-PXwE6J3+gRmDHr+FnJ45VYI1qFU=",
+      "requires": {
+        "camel-case": "1.1.1",
+        "constant-case": "1.1.0",
+        "dot-case": "1.1.1",
+        "is-lower-case": "1.1.1",
+        "is-upper-case": "1.1.1",
+        "lower-case": "1.1.2",
+        "lower-case-first": "1.0.0",
+        "param-case": "1.1.1",
+        "pascal-case": "1.1.0",
+        "path-case": "1.1.1",
+        "sentence-case": "1.1.2",
+        "snake-case": "1.1.1",
+        "swap-case": "1.1.0",
+        "title-case": "1.1.0",
+        "upper-case": "1.1.2",
+        "upper-case-first": "1.1.1"
+      },
       "dependencies": {
         "camel-case": {
           "version": "1.1.1",
-          "from": "camel-case@>=1.1.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-1.1.1.tgz"
+          "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-1.1.1.tgz",
+          "integrity": "sha1-ADXdePJKxMUw0TS3Jsw5tseZTDQ=",
+          "requires": {
+            "sentence-case": "1.1.2",
+            "upper-case": "1.1.2"
+          }
         },
         "constant-case": {
           "version": "1.1.0",
-          "from": "constant-case@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.0.tgz"
+          "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.0.tgz",
+          "integrity": "sha1-dTe4G0oTRzRF9dhYGBdp3g54VPo=",
+          "requires": {
+            "snake-case": "1.1.1",
+            "upper-case": "1.1.2"
+          }
         },
         "dot-case": {
           "version": "1.1.1",
-          "from": "dot-case@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-1.1.1.tgz"
+          "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-1.1.1.tgz",
+          "integrity": "sha1-nBg+eqD6yM23HFXbeDQKqAXwHXE=",
+          "requires": {
+            "sentence-case": "1.1.2"
+          }
         },
         "is-lower-case": {
           "version": "1.1.1",
-          "from": "is-lower-case@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.1.tgz"
+          "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.1.tgz",
+          "integrity": "sha1-otQKqpU/XuPxvz4HXy6DrFetVHw=",
+          "requires": {
+            "lower-case": "1.1.2"
+          }
         },
         "is-upper-case": {
           "version": "1.1.1",
-          "from": "is-upper-case@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.1.tgz"
+          "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.1.tgz",
+          "integrity": "sha1-k8BKbjktduhT/4ikoS7+lRHfIts=",
+          "requires": {
+            "upper-case": "1.1.2"
+          }
         },
         "lower-case": {
           "version": "1.1.2",
-          "from": "lower-case@>=1.1.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.2.tgz"
+          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.2.tgz",
+          "integrity": "sha1-AlaKR1WUkvvgpZ44XtSUgzzoyoo="
         },
         "lower-case-first": {
           "version": "1.0.0",
-          "from": "lower-case-first@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.0.tgz",
+          "integrity": "sha1-ofYm9MP9+rOGSNgGoH6oqnU6qGo=",
+          "requires": {
+            "lower-case": "1.1.2"
+          }
         },
         "param-case": {
           "version": "1.1.1",
-          "from": "param-case@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/param-case/-/param-case-1.1.1.tgz"
+          "resolved": "https://registry.npmjs.org/param-case/-/param-case-1.1.1.tgz",
+          "integrity": "sha1-7lvnHdt/XJMt19wJuRp3cw6sVg0=",
+          "requires": {
+            "sentence-case": "1.1.2"
+          }
         },
         "pascal-case": {
           "version": "1.1.0",
-          "from": "pascal-case@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.0.tgz"
+          "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.0.tgz",
+          "integrity": "sha1-wqHPBsAt3mhkuDDmPfhq9xnU9gc=",
+          "requires": {
+            "camel-case": "1.1.1",
+            "upper-case-first": "1.1.1"
+          }
         },
         "path-case": {
           "version": "1.1.1",
-          "from": "path-case@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/path-case/-/path-case-1.1.1.tgz"
+          "resolved": "https://registry.npmjs.org/path-case/-/path-case-1.1.1.tgz",
+          "integrity": "sha1-+8gdWdMX6VFX/t7psiSjKKy2j/4=",
+          "requires": {
+            "sentence-case": "1.1.2"
+          }
         },
         "sentence-case": {
           "version": "1.1.2",
-          "from": "sentence-case@>=1.1.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.2.tgz"
+          "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.2.tgz",
+          "integrity": "sha1-GZSOc/PjsYzTQ03VLedahhghlPk=",
+          "requires": {
+            "lower-case": "1.1.2"
+          }
         },
         "snake-case": {
           "version": "1.1.1",
-          "from": "snake-case@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-1.1.1.tgz"
+          "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-1.1.1.tgz",
+          "integrity": "sha1-4h1ovPBVd2FAWO//U+nUYMxGluI=",
+          "requires": {
+            "sentence-case": "1.1.2"
+          }
         },
         "swap-case": {
           "version": "1.1.0",
-          "from": "swap-case@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.0.tgz"
+          "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.0.tgz",
+          "integrity": "sha1-bmvEUx1WtqsPfvB7K3yYFgObNUc=",
+          "requires": {
+            "lower-case": "1.1.2",
+            "upper-case": "1.1.2"
+          }
         },
         "title-case": {
           "version": "1.1.0",
-          "from": "title-case@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/title-case/-/title-case-1.1.0.tgz"
+          "resolved": "https://registry.npmjs.org/title-case/-/title-case-1.1.0.tgz",
+          "integrity": "sha1-thXXJnhmZC20LQImeQBQi+WrJSs=",
+          "requires": {
+            "sentence-case": "1.1.2",
+            "upper-case": "1.1.2"
+          }
         },
         "upper-case": {
           "version": "1.1.2",
-          "from": "upper-case@>=1.1.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.2.tgz"
+          "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.2.tgz",
+          "integrity": "sha1-GJc/Vmhggx1WF3JO/VwbFc/SbTY="
         },
         "upper-case-first": {
           "version": "1.1.1",
-          "from": "upper-case-first@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.1.tgz"
+          "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.1.tgz",
+          "integrity": "sha1-f6e3DaD7aD4IHmh+KPM+w7NJwEs=",
+          "requires": {
+            "upper-case": "1.1.2"
+          }
         }
       }
     },
-    "node-whois": {
-      "version": "2.1.0",
-      "from": "node-whois@*",
-      "resolved": "https://registry.npmjs.org/node-whois/-/node-whois-2.1.0.tgz",
+    "commander": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+      "dev": true,
+      "requires": {
+        "graceful-readlink": "1.0.1"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "debug": {
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "diff": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "html-entities": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
+      "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+    },
+    "json3": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+      "dev": true
+    },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash.keys": "3.1.2"
+      }
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "dev": true
+    },
+    "lodash._basecreate": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
+      "dev": true
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+      "dev": true
+    },
+    "lodash.create": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+      "dev": true,
+      "requires": {
+        "lodash._baseassign": "3.2.0",
+        "lodash._basecreate": "3.0.3",
+        "lodash._isiterateecall": "3.0.9"
+      }
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.11"
+      }
+    },
+    "minimist": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      },
       "dependencies": {
-        "optimist": {
-          "version": "0.6.1",
-          "from": "optimist@>=0.6.1 <0.7.0",
-          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.10",
-              "from": "minimist@>=0.0.1 <0.1.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
-            },
-            "wordwrap": {
-              "version": "0.0.2",
-              "from": "wordwrap@>=0.0.2 <0.1.0",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-            }
-          }
-        },
-        "underscore": {
-          "version": "1.5.2",
-          "from": "underscore@>=1.5.2 <1.6.0",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.5.2.tgz"
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
         }
       }
+    },
+    "mocha": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
+      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.6.8",
+        "diff": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.1",
+        "growl": "1.9.2",
+        "he": "1.1.1",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "requires": {
+        "minimist": "0.0.10",
+        "wordwrap": "0.0.3"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "smart-buffer": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz",
+      "integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY="
+    },
+    "socks": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.10.tgz",
+      "integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
+      "requires": {
+        "ip": "1.1.5",
+        "smart-buffer": "1.1.15"
+      }
+    },
+    "supports-color": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+      "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+      "dev": true,
+      "requires": {
+        "has-flag": "1.0.0"
+      }
+    },
+    "underscore": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+    },
+    "whois": {
+      "version": "2.5.10",
+      "resolved": "https://registry.npmjs.org/whois/-/whois-2.5.10.tgz",
+      "integrity": "sha512-ZiNcEsgYDxBQEExYO/t1Mq1iY+//Glc4JR6cwUIFCHtZq5Y0KcBrPL/FOZ3cDb2p7RnjUPsIaDIz6up7N+nq4g==",
+      "requires": {
+        "optimist": "0.6.1",
+        "socks": "1.1.10",
+        "underscore": "1.8.3"
+      }
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "change-case": "^2.3.0",
     "html-entities": "^1.2.1",
-    "whois": "^2.1.0"
+    "whois": "^2.5.10"
   },
   "devDependencies": {
     "mocha": "^3.2.0"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "change-case": "^2.3.0",
+    "html-entities": "^1.2.1",
     "whois": "^2.1.0"
   },
   "devDependencies": {

--- a/parse-raw-data.js
+++ b/parse-raw-data.js
@@ -10,7 +10,7 @@ function parseRawData(rawData) {
 	lines.forEach(function(line){
 
 		line = line.trim();
-		if ( line && line.includes(': ') ) {
+		if ( line && line.includes(':') ) {
 			var lineParts = line.split(':');
 
 			// 'Greater than' since lines often have more than one colon, eg values with URLs

--- a/parse-raw-data.js
+++ b/parse-raw-data.js
@@ -1,12 +1,18 @@
 var os = require('os'),
 	log = console.log.bind(console),
-	changeCase = require('change-case');
+	changeCase = require('change-case'),
+	htmlEntities = require('html-entities').XmlEntities;
 
 function parseRawData(rawData) {
 
 	var result = {};
+	
+	// Parse HTML Entities
+	let entities = new htmlEntities();
+	
+	rawData = entities.decode(rawData);
 	var lines = rawData.split('\n');
-
+	
 	lines.forEach(function(line){
 
 		line = line.trim();

--- a/parse-raw-data.js
+++ b/parse-raw-data.js
@@ -11,12 +11,12 @@ function parseRawData(rawData) {
 	let entities = new htmlEntities();
 	rawData = entities.decode(rawData);
 	
-	// 	Handle .co.uk edge case where newline follows key (e.g. Registrant: \r\n google \r\n\r\n)
+	// Handle .co.uk edge case where newline follows key (e.g. Registrant: \r\n google \r\n\r\n)
 	rawData = rawData.replace(/:\s*\r\n/g, ': ');
 	var lines = rawData.split('\n');
 	
 	lines.forEach(function(line){
-
+	
 		line = line.trim();
 		if ( line && line.includes(':') ) {
 			var lineParts = line.split(':');

--- a/parse-raw-data.js
+++ b/parse-raw-data.js
@@ -5,12 +5,14 @@ var os = require('os'),
 
 function parseRawData(rawData) {
 
-	var result = {};
+	var result = {};	
 	
 	// Parse HTML Entities
 	let entities = new htmlEntities();
-	
 	rawData = entities.decode(rawData);
+	
+	// 	Handle .co.uk edge case where newline follows key (e.g. Registrant: \r\n google \r\n\r\n)
+	rawData = rawData.replace(/:\s*\r\n/g, ': ');
 	var lines = rawData.split('\n');
 	
 	lines.forEach(function(line){


### PR DESCRIPTION
Added the following:
1) HTML Entity encode
2) Fixed split in cases where semicolons are not followed by space
3) Support cases where the key (e.g. registrant: is followed by a newline before the value) - this happens in co.uk domains