### PR TITLE
iplookup

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var lookup = util.promisify(whois.lookup);
 
 module.exports = async function(domain, options){
 
-	var rawData = await lookup(domain, options || {})	
+	var rawData = await lookup(domain, options || {})
 
 	var result = {};
 
@@ -17,10 +17,13 @@ module.exports = async function(domain, options){
 			return data;
 		});
 	} else {
+		// let parsed = parseRawData(rawData);
+		// console.log(parsed);
+		// for (var i = parsed.length - 1; i >= 0; i--) {
+		// 		result = parsed[i];
+		// }
 		result = parseRawData(rawData);
 	}
 
 	return result;
 }
-
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,515 @@
+{
+  "name": "whois-json",
+  "version": "2.0.3",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
+    "camel-case": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+      "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+      "requires": {
+        "no-case": "^2.2.0",
+        "upper-case": "^1.1.1"
+      }
+    },
+    "change-case": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-3.0.2.tgz",
+      "integrity": "sha512-Mww+SLF6MZ0U6kdg11algyKd5BARbyM4TbFBepwowYSR5ClfQGCGtxNXgykpN0uF/bstWeaGDT4JWaDh8zWAHA==",
+      "requires": {
+        "camel-case": "^3.0.0",
+        "constant-case": "^2.0.0",
+        "dot-case": "^2.1.0",
+        "header-case": "^1.0.0",
+        "is-lower-case": "^1.1.0",
+        "is-upper-case": "^1.1.0",
+        "lower-case": "^1.1.1",
+        "lower-case-first": "^1.0.0",
+        "no-case": "^2.3.2",
+        "param-case": "^2.1.0",
+        "pascal-case": "^2.0.0",
+        "path-case": "^2.1.0",
+        "sentence-case": "^2.1.0",
+        "snake-case": "^2.1.0",
+        "swap-case": "^1.1.0",
+        "title-case": "^2.1.0",
+        "upper-case": "^1.1.1",
+        "upper-case-first": "^1.1.0"
+      }
+    },
+    "commander": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+      "dev": true,
+      "requires": {
+        "graceful-readlink": ">= 1.0.0"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "constant-case": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-2.0.0.tgz",
+      "integrity": "sha1-QXV2TTidP6nI7NKRhu1gBSQ7akY=",
+      "requires": {
+        "snake-case": "^2.1.0",
+        "upper-case": "^1.1.1"
+      }
+    },
+    "debug": {
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "dedent-js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dedent-js/-/dedent-js-1.0.1.tgz",
+      "integrity": "sha1-vuX7fJ5yfYXf+iRZDRDsGrElUwU="
+    },
+    "diff": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+      "dev": true
+    },
+    "dot-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-2.1.1.tgz",
+      "integrity": "sha1-NNzzf1Co6TwrO8qLt/uRVcfaO+4=",
+      "requires": {
+        "no-case": "^2.2.0"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.2",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "header-case": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/header-case/-/header-case-1.0.1.tgz",
+      "integrity": "sha1-lTWXMZfBRLCWE81l0xfvGZY70C0=",
+      "requires": {
+        "no-case": "^2.2.0",
+        "upper-case": "^1.1.3"
+      }
+    },
+    "html-entities": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
+      "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+    },
+    "is-lower-case": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz",
+      "integrity": "sha1-fhR75HaNxGbbO/shzGCzHmrWk5M=",
+      "requires": {
+        "lower-case": "^1.1.0"
+      }
+    },
+    "is-upper-case": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz",
+      "integrity": "sha1-jQsfp+eTOh5YSDYA7H2WYcuvdW8=",
+      "requires": {
+        "upper-case": "^1.1.0"
+      }
+    },
+    "json3": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+      "dev": true
+    },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keys": "^3.0.0"
+      }
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "dev": true
+    },
+    "lodash._basecreate": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
+      "dev": true
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+      "dev": true
+    },
+    "lodash.create": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+      "dev": true,
+      "requires": {
+        "lodash._baseassign": "^3.0.0",
+        "lodash._basecreate": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0"
+      }
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
+      }
+    },
+    "lower-case": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
+    },
+    "lower-case-first": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz",
+      "integrity": "sha1-5dp8JvKacHO+AtUrrJmA5ZIq36E=",
+      "requires": {
+        "lower-case": "^1.1.2"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
+      }
+    },
+    "mocha": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
+      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.6.8",
+        "diff": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.1",
+        "growl": "1.9.2",
+        "he": "1.1.1",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "no-case": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+      "requires": {
+        "lower-case": "^1.1.1"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "requires": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      }
+    },
+    "param-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
+      "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
+      "requires": {
+        "no-case": "^2.2.0"
+      }
+    },
+    "pascal-case": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-2.0.1.tgz",
+      "integrity": "sha1-LVeNNFX2YNpl7KGO+VtODekSdh4=",
+      "requires": {
+        "camel-case": "^3.0.0",
+        "upper-case-first": "^1.1.0"
+      }
+    },
+    "path-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/path-case/-/path-case-2.1.1.tgz",
+      "integrity": "sha1-lLgDfDctP+KQbkZbtF4l0ibo7qU=",
+      "requires": {
+        "no-case": "^2.2.0"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "sentence-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-2.1.1.tgz",
+      "integrity": "sha1-H24t2jnBaL+S0T+G1KkYkz9mftQ=",
+      "requires": {
+        "no-case": "^2.2.0",
+        "upper-case-first": "^1.1.2"
+      }
+    },
+    "smart-buffer": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz",
+      "integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY="
+    },
+    "snake-case": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-2.1.0.tgz",
+      "integrity": "sha1-Qb2xtz8w7GagTU4srRt2OH1NbZ8=",
+      "requires": {
+        "no-case": "^2.2.0"
+      }
+    },
+    "socks": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.10.tgz",
+      "integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
+      "requires": {
+        "ip": "^1.1.4",
+        "smart-buffer": "^1.0.13"
+      }
+    },
+    "supports-color": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+      "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+      "dev": true,
+      "requires": {
+        "has-flag": "^1.0.0"
+      }
+    },
+    "swap-case": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz",
+      "integrity": "sha1-w5IDpFhzhfrTyFCgvRvK+ggZdOM=",
+      "requires": {
+        "lower-case": "^1.1.1",
+        "upper-case": "^1.1.1"
+      }
+    },
+    "title-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/title-case/-/title-case-2.1.1.tgz",
+      "integrity": "sha1-PhJyFtpY0rxb7PE3q5Ha46fNj6o=",
+      "requires": {
+        "no-case": "^2.2.0",
+        "upper-case": "^1.0.3"
+      }
+    },
+    "underscore": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+    },
+    "upper-case": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
+    },
+    "upper-case-first": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz",
+      "integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
+      "requires": {
+        "upper-case": "^1.1.1"
+      }
+    },
+    "whois": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/whois/-/whois-2.6.0.tgz",
+      "integrity": "sha512-fPschemXwS7Id35Vnk3GoygHj5JgjcElVajSeF79DC+ayCm8E755PClQWvdgoOVovoag033JwZDq9Rz9+ABoJQ==",
+      "requires": {
+        "optimist": "^0.6.1",
+        "socks": "^1.1.10",
+        "underscore": "^1.5.2"
+      }
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -12,11 +12,20 @@
     "type": "git",
     "url": "https://github.com/mikemaccana/whois-json.git"
   },
+"contributors": [
+    {
+      "name": "Justin J. Novack",
+      "email": "jnovack@gmail.com"
+    }
+  ],
   "dependencies": {
     "change-case": "^3.0.2",
     "dedent-js": "^1.0.1",
     "html-entities": "^1.2.1",
     "whois": "^2.6.0"
+  },
+  "engines": {
+    "node": "> 8.0.0"
   },
   "devDependencies": {
     "mocha": "^3.2.0"

--- a/parse-raw-data.js
+++ b/parse-raw-data.js
@@ -11,15 +11,16 @@ var stripHTMLEntitites = function(rawData){
 }
 
 var parseRawData = function(rawData) {
-	
-	var result = {};	
-	
+
+	var result = [];
+
 	rawData = stripHTMLEntitites(rawData)
 	rawData = rawData.replace(/:\s*\r\n/g, ': ');
 	var lines = rawData.split('\n');
-	
+
+	entry = {};
 	lines.forEach(function(line){
-	
+
 		line = line.trim();
 		// colon space because that's the standard delimiter - not ':' as that's used in eg, http links
 		if ( line && line.includes(DELIMITER+' ') ) {
@@ -31,14 +32,37 @@ var parseRawData = function(rawData) {
 					value = lineParts.splice(1).join(DELIMITER).trim()
 
 				// If multiple lines use the same key, combine the values
-				if ( key in result ) {
-					result[key] = `${result[key]} ${value}`;
+				if ( key in entry ) {
+					entry[key] = `${entry[key]} ${value}`;
 					return
 				}
-				result[key] = value;
+				entry[key] = value;
 			}
 		}
+		if (line == '# end') {
+			result.push(entry);
+			entry = {};
+		}
 	});
+
+	if (result.length == 0) {
+		// only one result, return object
+		result = entry;
+	} else {
+		result.sort(function (a, b) {
+			// Sort Dsc  " > -1 "
+			// Sort Asc  " < -1 "
+			if (a.netHandle > b.netHandle) {
+				return -1;
+			}
+			if (a.netHandle < b.netHandle) {
+				return 1;
+			}
+
+			// names must be equal
+			return 0;
+		});
+	}
 
 	return result;
 }

--- a/test/tests.js
+++ b/test/tests.js
@@ -158,6 +158,312 @@ suite('parseRawData', function(){
 		assert.deepEqual(cleaned, correct)
 	})
 
+	test('converts raw ip data into JS', function(){
+		const rawData = dedent(`
+			% IANA WHOIS server
+			% for more information on IANA, visit http://www.iana.org
+			% This query returned 1 object
+
+			refer:        whois.arin.net
+
+			inetnum:      104.0.0.0 - 104.255.255.255
+			organisation: ARIN
+			status:       ALLOCATED
+
+			whois:        whois.arin.net
+
+			changed:      2011-02
+			source:       IANA
+
+
+			#
+			# ARIN WHOIS data and services are subject to the Terms of Use
+			# available at: https://www.arin.net/whois_tou.html
+			#
+			# If you see inaccuracies in the results, please report at
+			# https://www.arin.net/resources/whois_reporting/index.html
+			#
+			# Copyright 1997-2018, American Registry for Internet Numbers, Ltd.
+			#
+
+
+			#
+			# Query terms are ambiguous.  The query is assumed to be:
+			#     "n + 104.144.194.0"
+			#
+			# Use "?" to get help.
+			#
+
+
+			# start
+
+			NetRange:       104.144.0.0 - 104.144.255.255
+			CIDR:           104.144.0.0/16
+			NetName:        SERVERMANIA
+			NetHandle:      NET-104-144-0-0-2
+			Parent:         B2NETSOLUTIONS (NET-104-144-0-0-1)
+			NetType:        Reallocated
+			OriginAS:       AS55286
+			Organization:   B2 Net Solutions Inc. (BNS-34)
+			RegDate:        2014-07-22
+			Updated:        2014-07-22
+			Ref:            https://rdap.arin.net/registry/ip/104.144.0.0
+
+
+			OrgName:        B2 Net Solutions Inc.
+			OrgId:          BNS-34
+			Address:        2B-560 Arvin Avenue
+			City:           Stoney Creek
+			StateProv:      ON
+			PostalCode:     L8E 5P1
+			Country:        CA
+			RegDate:        2011-10-24
+			Updated:        2018-07-19
+			Comment:        https://servermania.com
+			Ref:            https://rdap.arin.net/registry/entity/BNS-34
+
+
+			OrgAbuseHandle: NOC13339-ARIN
+			OrgAbuseName:   Network Operations Center
+			OrgAbusePhone:  +1-716-745-4678
+			OrgAbuseEmail:  support@servermania.com
+			OrgAbuseRef:    https://rdap.arin.net/registry/entity/NOC13339-ARIN
+
+			OrgTechHandle: NOC13339-ARIN
+			OrgTechName:   Network Operations Center
+			OrgTechPhone:  +1-716-745-4678
+			OrgTechEmail:  support@servermania.com
+			OrgTechRef:    https://rdap.arin.net/registry/entity/NOC13339-ARIN
+
+			OrgNOCHandle: NOC13339-ARIN
+			OrgNOCName:   Network Operations Center
+			OrgNOCPhone:  +1-716-745-4678
+			OrgNOCEmail:  support@servermania.com
+			OrgNOCRef:    https://rdap.arin.net/registry/entity/NOC13339-ARIN
+
+			# end
+
+
+			# start
+
+			NetRange:       104.144.0.0 - 104.144.255.255
+			CIDR:           104.144.0.0/16
+			NetName:        B2NETSOLUTIONS
+			NetHandle:      NET-104-144-0-0-1
+			Parent:         NET104 (NET-104-0-0-0-0)
+			NetType:        Direct Allocation
+			OriginAS:
+			Organization:   B2 Net Solutions Inc. (BNS-34)
+			RegDate:        2014-07-22
+			Updated:        2014-07-22
+			Ref:            https://rdap.arin.net/registry/ip/104.144.0.0
+
+
+
+			OrgName:        B2 Net Solutions Inc.
+			OrgId:          BNS-34
+			Address:        2B-560 Arvin Avenue
+			City:           Stoney Creek
+			StateProv:      ON
+			PostalCode:     L8E 5P1
+			Country:        CA
+			RegDate:        2011-10-24
+			Updated:        2018-07-19
+			Comment:        https://servermania.com
+			Ref:            https://rdap.arin.net/registry/entity/BNS-34
+
+
+			OrgAbuseHandle: NOC13339-ARIN
+			OrgAbuseName:   Network Operations Center
+			OrgAbusePhone:  +1-716-745-4678
+			OrgAbuseEmail:  support@servermania.com
+			OrgAbuseRef:    https://rdap.arin.net/registry/entity/NOC13339-ARIN
+
+			OrgTechHandle: NOC13339-ARIN
+			OrgTechName:   Network Operations Center
+			OrgTechPhone:  +1-716-745-4678
+			OrgTechEmail:  support@servermania.com
+			OrgTechRef:    https://rdap.arin.net/registry/entity/NOC13339-ARIN
+
+			OrgNOCHandle: NOC13339-ARIN
+			OrgNOCName:   Network Operations Center
+			OrgNOCPhone:  +1-716-745-4678
+			OrgNOCEmail:  support@servermania.com
+			OrgNOCRef:    https://rdap.arin.net/registry/entity/NOC13339-ARIN
+
+			# end
+
+
+			# start
+
+			NetRange:       104.144.194.0 - 104.144.195.255
+			CIDR:           104.144.194.0/23
+			NetName:        NET-104-144-194-0-1
+			NetHandle:      NET-104-144-194-0-1
+			Parent:         SERVERMANIA (NET-104-144-0-0-2)
+			NetType:        Reassigned
+			OriginAS:
+			Customer:       ProxynVPN (C07015515)
+			RegDate:        2018-07-03
+			Updated:        2018-07-03
+			Ref:            https://rdap.arin.net/registry/ip/104.144.194.0
+
+
+			CustName:       ProxynVPN
+			Address:        746 Delaware Avenue
+			City:           Buffalo
+			StateProv:      NY
+			PostalCode:     14202
+			Country:        US
+			RegDate:        2018-07-03
+			Updated:        2018-07-03
+			Ref:            https://rdap.arin.net/registry/entity/C07015515
+
+			OrgAbuseHandle: NOC13339-ARIN
+			OrgAbuseName:   Network Operations Center
+			OrgAbusePhone:  +1-716-745-4678
+			OrgAbuseEmail:  support@servermania.com
+			OrgAbuseRef:    https://rdap.arin.net/registry/entity/NOC13339-ARIN
+
+			OrgTechHandle: NOC13339-ARIN
+			OrgTechName:   Network Operations Center
+			OrgTechPhone:  +1-716-745-4678
+			OrgTechEmail:  support@servermania.com
+			OrgTechRef:    https://rdap.arin.net/registry/entity/NOC13339-ARIN
+
+			OrgNOCHandle: NOC13339-ARIN
+			OrgNOCName:   Network Operations Center
+			OrgNOCPhone:  +1-716-745-4678
+			OrgNOCEmail:  support@servermania.com
+			OrgNOCRef:    https://rdap.arin.net/registry/entity/NOC13339-ARIN
+
+			# end
+
+
+
+			#
+			# ARIN WHOIS data and services are subject to the Terms of Use
+			# available at: https://www.arin.net/whois_tou.html
+			#
+			# If you see inaccuracies in the results, please report at
+			# https://www.arin.net/resources/whois_reporting/index.html
+			#
+			# Copyright 1997-2018, American Registry for Internet Numbers, Ltd.
+			#`);
+		const cleaned = parseRawData(rawData);
+		const correct = [ {
+ 			"address": "746 Delaware Avenue",
+ 			"cidr": "104.144.194.0/23",
+ 			"city": "Buffalo",
+ 			"country": "US",
+ 			"custName": "ProxynVPN",
+ 			"customer": "ProxynVPN (C07015515)",
+ 			"netHandle": "NET-104-144-194-0-1",
+ 			"netName": "NET-104-144-194-0-1",
+ 			"netRange": "104.144.194.0 - 104.144.195.255",
+ 			"netType": "Reassigned",
+ 			"orgAbuseEmail": "support@servermania.com",
+ 			"orgAbuseHandle": "NOC13339-ARIN",
+ 			"orgAbuseName": "Network Operations Center",
+ 			"orgAbusePhone": "+1-716-745-4678",
+ 			"orgAbuseRef": "https://rdap.arin.net/registry/entity/NOC13339-ARIN",
+ 			"orgNocEmail": "support@servermania.com",
+ 			"orgNocHandle": "NOC13339-ARIN",
+ 			"orgNocName": "Network Operations Center",
+ 			"orgNocPhone": "+1-716-745-4678",
+ 			"orgNocRef": "https://rdap.arin.net/registry/entity/NOC13339-ARIN",
+ 			"orgTechEmail": "support@servermania.com",
+ 			"orgTechHandle": "NOC13339-ARIN",
+ 			"orgTechName": "Network Operations Center",
+ 			"orgTechPhone": "+1-716-745-4678",
+ 			"orgTechRef": "https://rdap.arin.net/registry/entity/NOC13339-ARIN",
+ 			"parent": "SERVERMANIA (NET-104-144-0-0-2)",
+ 			"postalCode": "14202",
+ 			"ref": "https://rdap.arin.net/registry/ip/104.144.194.0 https://rdap.arin.net/registry/entity/C07015515",
+ 			"regDate": "2018-07-03 2018-07-03",
+ 			"stateProv": "NY",
+ 			"updated": "2018-07-03 2018-07-03"
+ 		}, {
+ 			"address": "2B-560 Arvin Avenue",
+ 			"availableAt": "https://www.arin.net/whois_tou.html",
+ 			"changed": "2011-02",
+ 			"cidr": "104.144.0.0/16",
+ 			"city": "Stoney Creek",
+ 			"comment": "https://servermania.com",
+ 			"country": "CA",
+ 			"inetnum": "104.0.0.0 - 104.255.255.255",
+ 			"netHandle": "NET-104-144-0-0-2",
+ 			"netName": "SERVERMANIA",
+ 			"netRange": "104.144.0.0 - 104.144.255.255",
+ 			"netType": "Reallocated",
+ 			"orgAbuseEmail": "support@servermania.com",
+ 			"orgAbuseHandle": "NOC13339-ARIN",
+ 			"orgAbuseName": "Network Operations Center",
+ 			"orgAbusePhone": "+1-716-745-4678",
+ 			"orgAbuseRef": "https://rdap.arin.net/registry/entity/NOC13339-ARIN",
+ 			"orgId": "BNS-34",
+ 			"orgName": "B2 Net Solutions Inc.",
+ 			"orgNocEmail": "support@servermania.com",
+ 			"orgNocHandle": "NOC13339-ARIN",
+ 			"orgNocName": "Network Operations Center",
+ 			"orgNocPhone": "+1-716-745-4678",
+ 			"orgNocRef": "https://rdap.arin.net/registry/entity/NOC13339-ARIN",
+ 			"orgTechEmail": "support@servermania.com",
+ 			"orgTechHandle": "NOC13339-ARIN",
+ 			"orgTechName": "Network Operations Center",
+ 			"orgTechPhone": "+1-716-745-4678",
+ 			"orgTechRef": "https://rdap.arin.net/registry/entity/NOC13339-ARIN",
+ 			"organisation": "ARIN",
+ 			"organization": "B2 Net Solutions Inc. (BNS-34)",
+ 			"originAs": "AS55286",
+ 			"parent": "B2NETSOLUTIONS (NET-104-144-0-0-1)",
+ 			"postalCode": "L8E 5P1",
+ 			"ref": "https://rdap.arin.net/registry/ip/104.144.0.0 https://rdap.arin.net/registry/entity/BNS-34",
+ 			"refer": "whois.arin.net",
+ 			"regDate": "2014-07-22 2011-10-24",
+ 			"source": "IANA",
+ 			"stateProv": "ON",
+ 			"status": "ALLOCATED",
+ 			"updated": "2014-07-22 2018-07-19",
+ 			"whois": "whois.arin.net"
+ 		}, {
+			"address": "2B-560 Arvin Avenue",
+ 			"cidr": "104.144.0.0/16",
+ 			"city": "Stoney Creek",
+ 			"comment": "https://servermania.com",
+ 			"country": "CA",
+ 			"netHandle": "NET-104-144-0-0-1",
+ 			"netName": "B2NETSOLUTIONS",
+ 			"netRange": "104.144.0.0 - 104.144.255.255",
+ 			"netType": "Direct Allocation",
+ 			"orgAbuseEmail": "support@servermania.com",
+ 			"orgAbuseHandle": "NOC13339-ARIN",
+ 			"orgAbuseName": "Network Operations Center",
+ 			"orgAbusePhone": "+1-716-745-4678",
+ 			"orgAbuseRef": "https://rdap.arin.net/registry/entity/NOC13339-ARIN",
+ 			"orgId": "BNS-34",
+ 			"orgName": "B2 Net Solutions Inc.",
+ 			"orgNocEmail": "support@servermania.com",
+ 			"orgNocHandle": "NOC13339-ARIN",
+ 			"orgNocName": "Network Operations Center",
+ 			"orgNocPhone": "+1-716-745-4678",
+ 			"orgNocRef": "https://rdap.arin.net/registry/entity/NOC13339-ARIN",
+ 			"orgTechEmail": "support@servermania.com",
+ 			"orgTechHandle": "NOC13339-ARIN",
+ 			"orgTechName": "Network Operations Center",
+ 			"orgTechPhone": "+1-716-745-4678",
+ 			"orgTechRef": "https://rdap.arin.net/registry/entity/NOC13339-ARIN",
+ 			"organization": "B2 Net Solutions Inc. (BNS-34)",
+ 			"parent": "NET104 (NET-104-0-0-0-0)",
+ 			"postalCode": "L8E 5P1",
+ 			"ref": "https://rdap.arin.net/registry/ip/104.144.0.0 https://rdap.arin.net/registry/entity/BNS-34",
+ 			"regDate": "2014-07-22 2011-10-24",
+ 			"stateProv": "ON",
+ 			"updated": "2014-07-22 2018-07-19"
+		} ];
+		assert.deepEqual(cleaned, correct);
+	});
+
 	test('real domain lookups', async function(){
 		this.timeout(3 * 1000)
 		const actual = await lookup('google.com')
@@ -166,12 +472,28 @@ suite('parseRawData', function(){
 		assert.equal(actual.registrarIanaId, 292)
 	});
 
+	test('real ip lookups', async function(){
+		this.timeout(3 * 1000)
+		const actual = await lookup('8.8.8.8')
+		// there's a good chance that these will not be reallocated in the lifetime of nodejs
+		assert.equal(actual[0].orgId, "GOGL");
+		assert.equal(actual[1].orgId, "LPL-141");
+	});
+
 	test('verbose real domain lookups', async function(){
 		this.timeout(3 * 1000)
 		const actual = await lookup('google.com', {verbose: true});
 		// Since results will change, just check some relevant fields.
 		assert.equal(actual[0].data.domainName, "GOOGLE.COM");
 		assert.equal(actual[0].data.registrarIanaId, 292);
+	});
+
+	test('verbose real ip lookups', async function(){
+		this.timeout(3 * 1000)
+		const actual = await lookup('8.8.8.8', {verbose: true})
+		// there's a good chance that these will not be reallocated in the lifetime of nodejs
+		assert.equal(actual.data[0].orgId, "GOGL");
+		assert.equal(actual.data[1].orgId, "LPL-141");
 	});
 
 	test('Geektools output with indented values and HTML entities', async function(){

--- a/test/tests.js
+++ b/test/tests.js
@@ -166,6 +166,14 @@ suite('parseRawData', function(){
 		assert.equal(actual.registrarIanaId, 292)
 	});
 
+	test('verbose real domain lookups', async function(){
+		this.timeout(3 * 1000)
+		const actual = await lookup('google.com', {verbose: true});
+		// Since results will change, just check some relevant fields.
+		assert.equal(actual[0].data.domainName, "GOOGLE.COM");
+		assert.equal(actual[0].data.registrarIanaId, 292);
+	});
+
 	test('Geektools output with indented values and HTML entities', async function(){
 		// Geektools is slow.
 		this.timeout(6 * 1000)

--- a/test/tests.js
+++ b/test/tests.js
@@ -13,7 +13,7 @@ const print = function(object){
 }
 
 suite('parseRawData', function(){
-	test('converts raw data into JS', function(){
+	test('converts raw domain data into JS', function(){
 		const rawData = dedent(`
 			Domain Name: google.com
 			Registry Domain ID: 2138514_DOMAIN_COM-VRSN
@@ -158,18 +158,18 @@ suite('parseRawData', function(){
 		assert.deepEqual(cleaned, correct)
 	})
 
-	test('real lookups', async function(){
+	test('real domain lookups', async function(){
 		this.timeout(3 * 1000)
 		const actual = await lookup('google.com')
 		// Since results will change, just check some relevant fields.
 		assert.equal(actual.domainName, "google.com")
 		assert.equal(actual.registrarIanaId, 292)
-	})	
+	});
 
 	test('Geektools output with indented values and HTML entities', async function(){
 		// Geektools is slow.
 		this.timeout(6 * 1000)
 		const actual = await lookup('google.co.uk', {server:'geektools.com'})
 		assert(actual.nameServers.includes("ns1.google.com"))
-	})	
+	});
 })


### PR DESCRIPTION
`parse-raw-data.js` was b0rked after the `concat` patch so this fixes that fix for domain lookups and corrects base output for ip lookups.  (#3 #4 #5).

An IP Lookup can return MULTIPLE entries (when domains are [reallocated or reassigned](https://www.arin.net/resources/request/reassignments.html)).  This PR returns all the IP ranges in reverse order so the smallest/most accurately allocated range is returned as `.[0]`, the largest range or owner will return as `[length-1]`.

When there is only 1 return (for a domain or ip lookup), it returns an object `{}`, however, when there are multiple returns, it returns an array of objects `[ {}, ... ]`.  I do not especially like this, as the upstream code then must figure out if `.key` or `[0].key` is the right key they require. HOWEVER, this is a backwards-compatible change.

I HEAVILY RECOMMEND fully bumping the version `2.x.x -> 3.0.0` and always implementing this as an array of objects, so regardless of a single or multiple returns, a key in the first result will always be `[0].key`.  This would be a breaking change, thus it warrants a major version bump.  I will start on that with your permission.

I have added tests for everything (my new adds for ip lookups and tests for verbose lookups (as the structure is different)).