### PR TITLE
Add the raw whois inside the result

### DIFF
--- a/parse-raw-data.js
+++ b/parse-raw-data.js
@@ -54,7 +54,7 @@ var parseRawData = function(rawData) {
 			}
 		}
 	});
-
+	result.rawWhois = rawData
 	return result;
 }
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -153,7 +153,8 @@ suite('parseRawData', function(){
 			"nameServer": "ns4.google.com ns2.google.com ns1.google.com ns3.google.com",
 			"dnssec": "unsigned",
 			"urlOfTheIcannWhoisDataProblemReportingSystem": "http://wdprs.internic.net/",
-			"lastUpdateOfWhoisDatabase": "2017-02-22T03:53:14-0800 <<<"
+			"lastUpdateOfWhoisDatabase": "2017-02-22T03:53:14-0800 <<<",
+			"rawWhois": rawData
 		};
 		assert.deepEqual(cleaned, correct)
 	})
@@ -294,7 +295,8 @@ suite('parseRawData', function(){
 			"urlOfTheIcannWhoisDataProblemReportingSystem": "http://wdprs.internic.net/",
 			"lastUpdateOfWhoisDatabase": "2018-12-23T14:08:06.00Z <<<:",
 			"forMoreInformationOnWhoisStatusCodesPleaseVisitHttps": "//icann.org/epp",
-			"underNoCircumstancesWillYouUseThisDataTo": ""
+			"underNoCircumstancesWillYouUseThisDataTo": "",
+			"rawWhois": rawData
 		};
 		assert.deepEqual(cleaned, correct)
 	})


### PR DESCRIPTION
Hi,

I just doing a small PR in order to add the raw Whois inside the returned object in order to be able to print it if necessary. 
I need it for an project.
All test passed. It would be a good idea to add this in documentation. If you want me to do that, just tell me and i'll do it as soon as possible.

Regards,

Le Poulet Suisse