### PR TITLE
Add support for `.jp` whois data parsing

### DIFF
--- a/parse-raw-data.js
+++ b/parse-raw-data.js
@@ -4,6 +4,7 @@ const os = require('os'),
 	htmlEntities = require('html-entities').XmlEntities;
 
 const DELIMITER = ':';
+const JPRS_DATABASE_HEADER = '[ JPRS database provides information on network administration. Its use is    ]';
 
 var stripHTMLEntitites = function(rawData){
 	var entities = new htmlEntities();
@@ -23,11 +24,24 @@ var getCommonDelimiterForm = function(rawData, delimiter) {
 	return delimiter + ' ';
 }
 
+var normaliseJprsData = function (data) {
+	// Normalise square bracketed keys to use colon delimiter, i.e. [Domain Name] => Domain Name:
+	var output = data.replace(/^\[([ \w]+)\]/gm, '$1:');
+	// Remove empty fields
+	output = output.replace(/^[ \w]+: *$/gm, '');
+	return output;
+}
+
 var parseRawData = function(rawData) {
 	
 	var result = {};	
 	
 	rawData = stripHTMLEntitites(rawData)
+
+	if (rawData.startsWith(JPRS_DATABASE_HEADER)) {
+		rawData = normaliseJprsData(rawData);
+	}
+
 	rawData = rawData.replace(/:\s*\r\n/g, ': ');
 	var lines = rawData.split('\n');
 	var delimiter = getCommonDelimiterForm(rawData, DELIMITER);

--- a/test/tests.js
+++ b/test/tests.js
@@ -298,6 +298,60 @@ suite('parseRawData', function(){
 		};
 		assert.deepEqual(cleaned, correct)
 	})
+
+	test('converts raw data from JPRS (Japan Registry Services) database', function(){
+		const rawData = dedent(`
+			[ JPRS database provides information on network administration. Its use is    ]
+			[ restricted to network administration purposes. For further information,     ]
+			[ use 'whois -h whois.jprs.jp help'. To suppress Japanese output, add'/e'     ]
+			[ at the end of command, e.g. 'whois -h whois.jprs.jp xxx/e'.                 ]
+			
+			Domain Information:
+			[Domain Name]                   GOOGLE.JP
+			
+			[Registrant]                    Google LLC
+			
+			[Name Server]                   ns1.google.com
+			[Name Server]                   ns2.google.com
+			[Name Server]                   ns3.google.com
+			[Name Server]                   ns4.google.com
+			[Signing Key]                   
+			
+			[Created on]                    2005/05/30
+			[Expires on]                    2021/05/31
+			[Status]                        Active
+			[Last Updated]                  2020/08/06 13:20:20 (JST)
+			
+			Contact Information:
+			[Name]                          Google LLC
+			[Email]                         dns-admin@google.com
+			[Web Page]                       
+			[Postal code]                   94043
+			[Postal Address]                Mountain View
+											1600 Amphitheatre Parkway
+											CA
+			[Phone]                         16502530000
+			[Fax]                           16502530001
+		`)
+		const cleaned = parseRawData(rawData)
+		const correct = {
+			"domainName": "GOOGLE.JP",
+			"registrant": "Google LLC",
+			"nameServer": "ns1.google.com ns2.google.com ns3.google.com ns4.google.com",
+			"createdOn": "2005/05/30",
+			"expiresOn": "2021/05/31",
+			"status": "Active",
+			"lastUpdated": "2020/08/06 13:20:20 (JST)",
+			"name": "Google LLC",
+			"email": "dns-admin@google.com",
+			"postalCode": "94043",
+			"postalAddress": "Mountain View",
+			"phone": "16502530000",
+			"fax": "16502530001"
+		};
+		assert.deepEqual(cleaned, correct)
+	})
+
 	test('IP Whois rawData when multiple records exist', function (){
 		const rawData = dedent(`
 			#


### PR DESCRIPTION
ℹ️ I realise this library is fairly generic and light, so feel free to close if you'd rather not add specific edge case handling.


## The Problem

Whois results show incorrectly for `*.jp`  domains with the current library release:

Querying `whois('google.jp')`
```json
{ 
  "domainInformation": "[Domain Name]                   GOOGLE.JP",
  "contactInformation": "[Name]                          Google LLC"
}
```

## Why
Because the Japan Registry Services whois results are not using the popular colon-delimited whois data format. 

It uses square brackets for fields. 

```
[ JPRS database provides information on network administration. Its use is    ]
[ restricted to network administration purposes. For further information,     ]
[ use 'whois -h whois.jprs.jp help'. To suppress Japanese output, add'/e'     ]
[ at the end of command, e.g. 'whois -h whois.jprs.jp xxx/e'.                 ]

Domain Information:
[Domain Name]                   GOOGLE.JP

[Registrant]                    Google LLC

[Name Server]                   ns1.google.com
[Name Server]                   ns2.google.com
[Name Server]                   ns3.google.com
[Name Server]                   ns4.google.com
...
```

## Solution

I've opted for handling this case specifically based on whether the header used by the JPRS database is present.

We then:
- Normalise all square bracketed keys to use colon delimiter `[Domain Name] -> Domain Name:`
- Remove empty keys

Then the normal parsing of the data resumes.

An alternative could be to try a more generic normalisation of all results. 

Thanks for the library! Happy to adjust this PR based on your feedback 😄 